### PR TITLE
Fix three code bugs

### DIFF
--- a/local-llm-tool-calling/local-agent-with-ui.py
+++ b/local-llm-tool-calling/local-agent-with-ui.py
@@ -113,7 +113,9 @@ Any message that starts with "Thought:" is you thinking to yourself. This isn't 
 Don't repeat an action. If a thought tells you that you already took an action for a user, don't do it again.
 """       
 
-def prompt_ai(messages, nested_calls=0, invoked_tools=[]):
+def prompt_ai(messages, nested_calls=0, invoked_tools=None):
+    if invoked_tools is None:
+        invoked_tools = []
     if nested_calls > 3:
         raise Exception("Failsafe - AI is failing too much!")
 
@@ -123,8 +125,9 @@ def prompt_ai(messages, nested_calls=0, invoked_tools=[]):
 
     try:
         ai_response = asana_chatbot.invoke(messages)
-    except:
-        return prompt_ai(messages, nested_calls + 1)
+    except Exception as e:
+        print(e)
+        return prompt_ai(messages, nested_calls + 1, invoked_tools)
     print(ai_response)
 
     # Second, see if the AI decided it needs to invoke a tool

--- a/o1-ai-agent/o1-ai-agent.py
+++ b/o1-ai-agent/o1-ai-agent.py
@@ -27,7 +27,7 @@ api_client = asana.ApiClient(configuration)
 projects_api_instance = asana.ProjectsApi(api_client)
 tasks_api_instance = asana.TasksApi(api_client)
 
-workspace_gid = os.getenv("ASANA_WORKPLACE_ID", "")
+workspace_gid = os.getenv("ASANA_WORKSPACE_ID", "")
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -256,7 +256,9 @@ def add_thought(thought):
         with st.chat_message("assistant"):
             st.markdown(thought)       
 
-def prompt_ai(nested_calls=0, invoked_tools=[]):
+def prompt_ai(nested_calls=0, invoked_tools=None):
+    if invoked_tools is None:
+        invoked_tools = []
     if nested_calls > 10:
         raise Exception("Failsafe - AI is failing too much!")
 
@@ -268,7 +270,7 @@ def prompt_ai(nested_calls=0, invoked_tools=[]):
         ai_response = asana_chatbot.invoke(st.session_state.messages)
     except Exception as e:
         print(e)
-        return prompt_ai(nested_calls + 1)
+        return prompt_ai(nested_calls + 1, invoked_tools)
     print(ai_response)
 
     # Second, see if the AI decided it needs to invoke a tool


### PR DESCRIPTION
Fix default mutable arguments and bare excepts in `prompt_ai` functions and correct the `ASANA_WORKPLACE_ID` environment variable typo.

The default mutable arguments (`invoked_tools=[]`) caused state to persist across calls, leading to incorrect tool invocation logic. The bare `except` in `local-agent-with-ui.py` hid errors and dropped the `invoked_tools` list during recursion, potentially causing infinite loops or missed deduplication. The environment variable typo prevented the correct Asana workspace ID from being loaded, breaking Asana integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ba614ae-71cc-43f1-bd86-96e8cbe66f15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ba614ae-71cc-43f1-bd86-96e8cbe66f15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

